### PR TITLE
Make sorted read and sorted write optional

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='py-gtfs-loader',
-      version='0.0.4',
+      version='0.1.0',
       description='Load GTFS',
       url='https://github.com/TransitApp/py-gtfs-loader',
       author='Nicholas Paun, Jonathan Milot',

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='py-gtfs-loader',
-      version='0.0.3',
+      version='0.0.4',
       description='Load GTFS',
       url='https://github.com/TransitApp/py-gtfs-loader',
       author='Nicholas Paun, Jonathan Milot',


### PR DESCRIPTION
py-gtfs-loader used to always sort all the rows it read or wrote. This PR disables this behaviour by default. This will produce smaller diffs when run on feeds that are already in a particular order, and improve compatibility with legacy systems that make assumptions around row order.

The sorting feature produces easier-to-read consistent output, so it is retained for use in unit tests.