### PR TITLE
Do not output empty gtfs file

### DIFF
--- a/gtfs_loader/__init__.py
+++ b/gtfs_loader/__init__.py
@@ -1,6 +1,7 @@
 import csv
 import enum
 import json
+import os
 import shutil
 import typing
 from pathlib import Path
@@ -224,6 +225,9 @@ def patch(gtfs, gtfs_in_dir, gtfs_out_dir, sorted_output=False):
     for file_schema in schema.GTFS_SUBSET_SCHEMA.values():
         print(f'Writing {file_schema.name}')
         entities = gtfs.get(file_schema.name)
+        if not entities:
+            delete_file(file_schema, gtfs_out_dir)
+            continue
 
         if file_schema.fileType is schema_classes.FileType.CSV:
             save_csv(file_schema, entities, gtfs_out_dir, sorted_output)
@@ -251,6 +255,13 @@ def save_csv(file_schema, entities, gtfs_out_dir, sorted_output=False):
 def save_json(file_schema, entities, gtfs_out_dir):
     with open(gtfs_out_dir / (file_schema.filename), 'w', encoding='utf-8') as f:
         f.write(json.dumps(entities, indent=4, default=vars))
+
+
+def delete_file(file_schema, gtfs_out_dir):
+    try:
+        os.remove(gtfs_out_dir / (file_schema.filename))
+    except OSError:
+        pass
 
 
 def flatten_entities(file_schema, entities):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='py-gtfs-loader',
-      version='0.1.9',
+      version='0.1.10',
       description='Load GTFS',
       url='https://github.com/TransitApp/py-gtfs-loader',
       author='Nicholas Paun, Jonathan Milot',


### PR DESCRIPTION
As per a discussion with @jsteelz, it's easier to handle if this doesn't output empty file. 

I also added a step to be sure we deleted files from previous run if the same `gtfs_out_dir` was used. 