### PR TITLE
force stop_times sorting to ensure giving accurate first/last stop time information

### DIFF
--- a/gtfs_loader/__init__.py
+++ b/gtfs_loader/__init__.py
@@ -29,7 +29,7 @@ def load(gtfs_dir, sorted_read=False):
                 continue
 
         if file_schema.fileType is schema_classes.FileType.CSV:
-            load_csv(gtfs, filepath, file_schema, sorted_read=(True if file_schema.name == 'stop_times' else sorted_read))
+            load_csv(gtfs, filepath, file_schema, sorted_read=(True if file_schema.name == 'stop_times' or file_schema.name == 'shapes' else sorted_read))
         elif file_schema.fileType is schema_classes.FileType.GEOJSON:
             load_json(gtfs, filepath, file_schema)
 

--- a/gtfs_loader/__init__.py
+++ b/gtfs_loader/__init__.py
@@ -29,7 +29,7 @@ def load(gtfs_dir, sorted_read=False):
                 continue
 
         if file_schema.fileType is schema_classes.FileType.CSV:
-            load_csv(gtfs, filepath, file_schema, sorted_read)
+            load_csv(gtfs, filepath, file_schema, sorted_read=(True if file_schema.name == 'stop_times' else sorted_read))
         elif file_schema.fileType is schema_classes.FileType.GEOJSON:
             load_json(gtfs, filepath, file_schema)
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='py-gtfs-loader',
-      version='0.1.11',
+      version='0.1.12',
       description='Load GTFS',
       url='https://github.com/TransitApp/py-gtfs-loader',
       author='Nicholas Paun, Jonathan Milot',


### PR DESCRIPTION
if stop_times are not ordered by stop_sequence in the CSV being read, the first_ and last_ stop time getters will return incorrect results.