### PR TITLE
py-gtfs-loader: verbosity, file-loading/exporting controls

### DIFF
--- a/gtfs_loader/schema.py
+++ b/gtfs_loader/schema.py
@@ -326,3 +326,17 @@ class Trip(Entity):
 
 GTFS_SUBSET_SCHEMA = FileCollection(Agency, BookingRule, Calendar, CalendarDate,
                                     Locations, LocationGroups, Routes, Transfer, Trip, Stop, StopTime)
+
+GTFS_FILENAMES = {
+    Agency._schema.name: Agency,
+    BookingRule._schema.name: BookingRule,
+    Calendar._schema.name: Calendar,
+    CalendarDate._schema.name: CalendarDate,
+    Locations._schema.name: Locations,
+    LocationGroups._schema.name: LocationGroups,
+    Routes._schema.name: Routes,
+    Transfer._schema.name: Transfer,
+    Trip._schema.name: Trip,
+    Stop._schema.name: Stop,
+    StopTime._schema.name: StopTime,
+}

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='py-gtfs-loader',
-      version='0.1.12',
+      version='0.1.13',
       description='Load GTFS',
       url='https://github.com/TransitApp/py-gtfs-loader',
       author='Nicholas Paun, Jonathan Milot',

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -16,6 +16,6 @@ def test_default(feed_dir):
 def do_test(feed_dir):
     work_dir = test_support.create_test_data(feed_dir)
 
-    gtfs = gtfs_loader.load(work_dir)
-    gtfs_loader.patch(gtfs, work_dir, work_dir)
+    gtfs = gtfs_loader.load(work_dir, verbose=False)
+    gtfs_loader.patch(gtfs, work_dir, work_dir, verbose=False)
     test_support.check_expected_output(feed_dir, work_dir)


### PR DESCRIPTION
Internal modules at transit often don't need to load all of a gtfs, and instead only need to read a few files.

Additionally, add a control for logging import/export of files.